### PR TITLE
changed instances of 'app url' to 'app domain' to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Regardless of the option you choose, the tool will require you to input some inf
 3. If you're using Docker, build and run your Docker image with the above commands
 4. Input the following generic command:
 ```
-$ cis-integration code-engine -n [CIS NAME] -d [CIS DOMAIN] -a [CODE ENGINE APP URL]
+$ cis-integration code-engine -n [CIS NAME] -d [CIS DOMAIN] -a [CODE ENGINE APP DOMAIN]
 ```
 An alternative command is also available:
 ```
-$ cis-integration code-engine -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [CODE ENGINE APP URL]
+$ cis-integration code-engine -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [CODE ENGINE APP DOMAIN]
 ```
 ### Arguments:
 * **CIS NAME:** the name of your CIS instance.
@@ -82,7 +82,7 @@ $ cis-integration code-engine -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [
     Example: `ae3445ji01b31lvi934jlaef09fad1lc`
 * **CIS DOMAIN:** the domain name connected to your CIS instance. Found near the top of your CIS resource page. 
     Example: `example.com`
-* **CODE ENGINE APP URL:** the URL of your Code Engine application. Found by navigating to your Code Engine application page and clicking on "Open application URL". 
+* **CODE ENGINE APP DOMAIN:** the hostname of your Code Engine application. Found by navigating to your Code Engine application page and clicking on "Open application URL". 
     Example: `example-app.8jl3icnad39.us-south.codeengine.appdomain.cloud`
 
 ### To deploy resources using Terraform scripts:
@@ -91,14 +91,14 @@ $ cis-integration code-engine -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [
 3. If you're using Docker, build and run your Docker image with the above commands
 4. Input the following generic command:
 ```
-$ cis-integration code-engine --terraform -r [RESOURCE GROUP] -n [CIS NAME] -d [CIS DOMAIN] -a [CODE ENGINE APP URL]
+$ cis-integration code-engine --terraform -r [RESOURCE GROUP] -n [CIS NAME] -d [CIS DOMAIN] -a [CODE ENGINE APP DOMAIN]
 ```
 ### Arguments:
 * **RESOURCE GROUP:** the resource group connected to the CIS instance. Found by navigating to your CIS resource page and clicking on "Details".
 * **CIS NAME:** the name of your CIS instance.
 * **CIS DOMAIN:** the domain name connected to your CIS instance. Found near the top of your CIS resource page. 
     Example: `example.com`
-* **CODE ENGINE APP URL:** the URL of your Code Engine application. Found by navigating to your Code Engine application page and clicking on "Open application URL". 
+* **CODE ENGINE APP DOMAIN:** the hostname of your Code Engine application. Found by navigating to your Code Engine application page and clicking on "Open application URL". 
     Example: `example-app.8jl3icnad39.us-south.codeengine.appdomain.cloud`
 
 **Note:** For the origin pool, origin name, and health check resources, this tool builds them using generic names. If you would like to change these later, navigate to the "Reliability" tab of your CIS instance and click on the "Global load balancers" tab. You can find your origin pools and health checks here and edit them manually.
@@ -112,7 +112,7 @@ API_ENDPOINT="https://api.cis.cloud.ibm.com"
 CIS_SERVICES_APIKEY="<YOUR_CIS_SERVICES_APIKEY>"
 CIS_NAME="<CIS_INSTANCE_NAME>"
 RESOURCE_GROUP="<YOUR_IBM_CLOUD_RESOURCE_GROUP>"
-APP_URL="<CODE_ENGINE_APP_URL>"
+APP_DOMAIN="<CODE_ENGINE_APP_DOMAIN>"
 CIS_DOMAIN="<DOMAIN_NAME>"
 ```
 Example usage

--- a/src/codeEngine.py
+++ b/src/codeEngine.py
@@ -29,9 +29,9 @@ def print_help():
     print("\t- call this tool with either 'cis-integration' or 'ci'\n")
 
     print(Color.BOLD + "USAGE:" + Color.END)
-    print("\t[python command]\t\tcis-integration [positional args] [global options] -n [CIS NAME] -d [CIS DOMAIN] -a [APP URL]")
-    print("\t[alt python command]\t\tcis-integration [positional args] [global options] -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [APP URL] \n")
-    print("\t[terraform command]\t\tcis-integration [positional args] [global options] --terraform -r [RESOURCE GROUP] -n [CIS NAME] -d [CIS DOMAIN] -a [APP URL]\n")
+    print("\t[python command]\t\tcis-integration [positional args] [global options] -n [CIS NAME] -d [CIS DOMAIN] -a [APP DOMAIN]")
+    print("\t[alt python command]\t\tcis-integration [positional args] [global options] -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [APP DOMAIN] \n")
+    print("\t[terraform command]\t\tcis-integration [positional args] [global options] --terraform -r [RESOURCE GROUP] -n [CIS NAME] -d [CIS DOMAIN] -a [APP DOMAIN]\n")
     print("\t[delete command]\t\tcis-integration [positional args] [global options] --delete -n [CIS NAME] -d [CIS DOMAIN]")
     print("\t[alt delete command]\t\tcis-integration [positional args] [global options] --delete -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN]\n")
 
@@ -49,7 +49,7 @@ def print_help():
     print("\t--crn, -c \t\t CRN of the CIS instance")
     print("\t--zone_id, -z \t\t Zone ID of the CIS instance")
     print("\t--cis_domain, -d \t domain name of the CIS instance")
-    print("\t--app_url, -a \t\t URL of the application")
+    print("\t--app, -a \t\t hostname of the application")
     print("\t--resource_group, -r \t resource group associated with the CIS instance")
     print("\t--name, -n \t\t name of the CIS instance")
 
@@ -82,9 +82,9 @@ def handle_args(args):
     # common arguments
     
     if not UserInfo.delete:
-        UserInfo.app_url = args.app_url
+        UserInfo.app_url = args.app
         if UserInfo.app_url is None:
-            print("You did not specify an application URL.")
+            print("You did not specify an application domain.")
             sys.exit(1)
 
     UserInfo.cis_domain = args.cis_domain

--- a/src/functions.py
+++ b/src/functions.py
@@ -83,12 +83,12 @@ class IntegrationInfo:
                 self.cis_name=env_vars["CIS_NAME"]
 
         
-        if "API_ENDPOINT" not in env_vars or "CIS_SERVICES_APIKEY" not in env_vars or "CIS_DOMAIN" not in env_vars or "APP_URL" not in env_vars:
+        if "API_ENDPOINT" not in env_vars or "CIS_SERVICES_APIKEY" not in env_vars or "CIS_DOMAIN" not in env_vars or "APP_DOMAIN" not in env_vars:
             print("Missing one or more necessary attributes in .env!")
             sys.exit(1)
         else:
             self.cis_domain=env_vars["CIS_DOMAIN"]
-            self.app_url=env_vars["APP_URL"]
+            self.app_url=env_vars["APP_DOMAIN"]
             self.cis_api_key=env_vars["CIS_SERVICES_APIKEY"]
             self.api_endpoint=env_vars["API_ENDPOINT"]
     

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ def main():
     ce_parser.add_argument("-c","--crn")
     ce_parser.add_argument("-z","--zone_id")
     ce_parser.add_argument("-d","--cis_domain")
-    ce_parser.add_argument("-a","--app_url")
+    ce_parser.add_argument("-a","--app")
     ce_parser.add_argument("-t","--terraform", action='store_true')
     ce_parser.add_argument("-r","--resource_group")
     ce_parser.add_argument("-n","--name")


### PR DESCRIPTION
To make clear that the user must input the hostname of their application instead of the URL, all messages referencing an "app url" were changed to "app domain".