### PR TITLE
Creating DNS Records

### DIFF
--- a/src/codeEngine.py
+++ b/src/codeEngine.py
@@ -80,7 +80,8 @@ def handle_args(args):
     os.environ["CIS_SERVICES_APIKEY"] = UserInfo.cis_api_key
     
     # common arguments
-    
+    UserInfo.request_token()
+
     if not UserInfo.delete:
         UserInfo.app_url = args.app
         if UserInfo.app_url is None:
@@ -138,15 +139,27 @@ def CodeEngine(args):
         delete_certs = DeleteCerts(UserInfo.crn, UserInfo.zone_id, UserInfo.api_endpoint, UserInfo.cis_domain)
         delete_certs.delete_certs()
 
-        delete_edge = DeleteEdge(UserInfo.crn, UserInfo.zone_id, UserInfo.cis_domain, UserInfo.cis_api_key)
+        delete_edge = DeleteEdge(UserInfo.crn, UserInfo.zone_id, 
+            UserInfo.cis_domain, UserInfo.cis_api_key, UserInfo.token["access_token"])
         delete_edge.delete_edge()
 
         if UserInfo.terraforming:
-            delete_workspaces = DeleteWorkspace(UserInfo.schematics_url, UserInfo.cis_api_key)
+            delete_workspaces = DeleteWorkspace(UserInfo.schematics_url, UserInfo.cis_api_key, UserInfo.token)
             delete_workspaces.delete_workspace()
 
     elif UserInfo.terraforming: # handle the case of using terraform
-        work_creator = WorkspaceCreator(UserInfo.cis_api_key, UserInfo.schematics_url, UserInfo.app_url, UserInfo.cis_domain, UserInfo.resource_group, UserInfo.cis_name, UserInfo.api_endpoint, UserInfo.crn, UserInfo.zone_id, UserInfo.verbose)
+        work_creator = WorkspaceCreator(
+            UserInfo.cis_api_key,
+            UserInfo.schematics_url, 
+            UserInfo.app_url, 
+            UserInfo.cis_domain, 
+            UserInfo.resource_group, 
+            UserInfo.cis_name, 
+            UserInfo.api_endpoint, 
+            UserInfo.crn, 
+            UserInfo.zone_id, 
+            UserInfo.verbose, 
+            UserInfo.token)
         work_creator.create_terraform_workspace()
     else: # handle the case of using python
         # 1. Domain Name and DNS
@@ -164,7 +177,10 @@ def CodeEngine(args):
         cert_creator.create_certificate()
 
         # 4. Edge Functions
-        userEdgeFunction = EdgeFunctionCreator(UserInfo.crn, UserInfo.app_url, UserInfo.cis_api_key, UserInfo.zone_id, UserInfo.cis_domain)
+        userEdgeFunction = EdgeFunctionCreator(
+            UserInfo.crn, UserInfo.app_url, 
+            UserInfo.cis_api_key, UserInfo.zone_id, 
+            UserInfo.cis_domain, UserInfo.token["access_token"])
         userEdgeFunction.create_edge_function_action()
         userEdgeFunction.create_edge_function_trigger()
         userEdgeFunction.create_edge_function_wild_card_trigger()

--- a/src/create_edge_function.py
+++ b/src/create_edge_function.py
@@ -2,14 +2,15 @@ import requests, json
 from src.functions import Color as Color
 
 class EdgeFunctionCreator:
-    def __init__(self, crn, app_url, apikey, zone_id, domain):
+    def __init__(self, crn, app_url, apikey, zone_id, domain, token):
         self.crn = crn
         self.app_url = app_url
         self.apikey = apikey
         self.zone_id = zone_id
         self.domain = domain
         self.fn_name = self.domain.replace('.', '-') # The name of the edge function action
-        self.token = self.request_token(self.apikey)
+        self.token = token
+        #self.token = self.request_token(self.apikey)
 
     def create_edge_function_action(self):
 
@@ -113,6 +114,7 @@ class EdgeFunctionCreator:
 
         return trigger_response_3
 
+    '''
     def request_token(self, apikey: str):
         """
         Requests an access token for the client so that we can execute the plan and apply commands in
@@ -128,3 +130,4 @@ class EdgeFunctionCreator:
         url="https://iam.cloud.ibm.com/identity/token"
         token = requests.post(url=url, data=data, headers=headers)
         return token.json()["access_token"] 
+    '''

--- a/src/delete_edge.py
+++ b/src/delete_edge.py
@@ -3,26 +3,27 @@ import requests
 from src.functions import Color
 
 class DeleteEdge:
-    def __init__(self, crn: str, zone_id: str, cis_domain: str, apikey: str) -> None:
+    def __init__(self, crn: str, zone_id: str, cis_domain: str, apikey: str, token: str) -> None:
         self.crn = crn
         self.zone_id = zone_id
         self.cis_domain = cis_domain
         self.apikey = apikey
+        self.token = token
 
     def delete_edge(self):
         execute = input("Delete edge function? Input 'y' or 'yes' to execute: ").lower()
         if execute == 'y' or execute == 'yes':
             action_name = self.cis_domain.replace('.','-')
-            token = self.request_token(self.apikey)
+            #token = self.request_token(self.apikey)
             
-            triggers = self.get_triggers(self.crn, self.zone_id, token)
+            triggers = self.get_triggers(self.crn, self.zone_id, self.token)
 
             for trigger in triggers["result"]:
                 if trigger["script"] == action_name:
-                    self.delete_trigger(self.crn, self.zone_id, trigger["id"], token)
+                    self.delete_trigger(self.crn, self.zone_id, trigger["id"],self.token)
                     print(Color.GREEN + "SUCCESS: Deleted trigger " + trigger["pattern"] + Color.END)
 
-            action_response = self.delete_action(self.crn, action_name, token)
+            action_response = self.delete_action(self.crn, action_name, self.token)
             if action_response["success"]:
                 print(Color.GREEN + "SUCCESS: Deleted edge function action with id " + action_response["result"]["id"] + Color.END)
             else:
@@ -63,6 +64,7 @@ class DeleteEdge:
         response = requests.request("DELETE", url, headers=headers).json()
         return response
 
+    '''
     def request_token(self, apikey: str):
             """
             Requests an access token for the client so that we can execute the plan and apply commands in
@@ -78,3 +80,4 @@ class DeleteEdge:
             url="https://iam.cloud.ibm.com/identity/token"
             token = requests.post(url=url, data=data, headers=headers)
             return token.json()["access_token"] 
+    '''

--- a/src/delete_workspaces.py
+++ b/src/delete_workspaces.py
@@ -3,15 +3,16 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 import os, requests
 
 class DeleteWorkspace:
-    def __init__(self, schematics_url: str, apikey: str) -> None:
+    def __init__(self, schematics_url: str, apikey: str, token) -> None:
         self.schematics_url = schematics_url
         self.apikey = apikey
+        self.token = token
 
     def delete_workspace(self):
         w_ids = []
         execute = input("Delete all associated Schematics workspaces? Input 'y' or 'yes' to execute: ").lower()
         if execute == 'y' or execute == 'yes':
-            token = self.request_token(self.apikey)
+            #token = self.request_token(self.apikey)
             authenticator = IAMAuthenticator(self.apikey)
             schematics_service = SchematicsV1(authenticator = authenticator)
             schematics_service.set_service_url(self.schematics_url)
@@ -26,13 +27,13 @@ class DeleteWorkspace:
             for id in w_ids:
                 workspace_delete_response = schematics_service.delete_workspace(
                     w_id=id,
-                    refresh_token=token['refresh_token']
+                    refresh_token=self.token['refresh_token']
                 )
                 if workspace_delete_response.status_code == 200:
                     num_deleted += 1
             print("Deleted " + str(num_deleted) + " associated workspaces")
         
-
+    '''
     def request_token(self, apikey: str):
             """
             Requests a refresh token for the client so that we can execute the plan and apply commands in
@@ -49,3 +50,4 @@ class DeleteWorkspace:
             url="https://iam.cloud.ibm.com/identity/token"
             token = requests.post(url=url, data=data, headers=headers)
             return token.json()
+    '''

--- a/src/functions.py
+++ b/src/functions.py
@@ -53,7 +53,7 @@ class IntegrationInfo:
     crn = ''
     zone_id = ''
     api_endpoint = 'https://api.cis.cloud.ibm.com'
-    cluster_id = ''
+    iks_cluster_id = ''
     app_url = ''
     resource_group = ''
     cis_name = ''
@@ -110,19 +110,20 @@ class IntegrationInfo:
             self.token = requests.post(url=url, data=data, headers=headers)
             return self.token.json()
 
-    def get_iks_info(self, token: str):
+    def get_iks_info(self):
 
-        url = "https://containers.cloud.ibm.com/global/v1/nlb-dns/clusters/" + self.cluster_id + "/list"
+        url = "https://containers.cloud.ibm.com/global/v1/nlb-dns/clusters/" + self.iks_cluster_id + "/list"
 
         headers = {
         'Accept': 'application/json',
-        'Authorization': 'Bearer ' + token
+        'Authorization': 'Bearer ' + self.token.json()["access_token"]
         }
 
-        response = requests.request("GET", url, headers=headers)
+        response = requests.request("GET", url, headers=headers).json()
 
-        print(response.text)
-
+        for cluster in response["nlbs"]:
+            if cluster["clusterID"] == self.iks_cluster_id:
+                self.app_url = cluster["nlbHost"]
         return response
 
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -107,8 +107,8 @@ class IntegrationInfo:
                     'Content-type': 'application/x-www-form-urlencoded',
                     'Authorization': 'Basic Yng6Yng='}
             url="https://iam.cloud.ibm.com/identity/token"
-            self.token = requests.post(url=url, data=data, headers=headers)
-            return self.token.json()
+            self.token = requests.post(url=url, data=data, headers=headers).json()
+            return self.token
 
     def get_iks_info(self):
 
@@ -116,7 +116,7 @@ class IntegrationInfo:
 
         headers = {
         'Accept': 'application/json',
-        'Authorization': 'Bearer ' + self.token.json()["access_token"]
+        'Authorization': 'Bearer ' + self.token["access_token"]
         }
 
         response = requests.request("GET", url, headers=headers).json()

--- a/src/functions.py
+++ b/src/functions.py
@@ -53,6 +53,7 @@ class IntegrationInfo:
     crn = ''
     zone_id = ''
     api_endpoint = 'https://api.cis.cloud.ibm.com'
+    cluster_id = ''
     app_url = ''
     resource_group = ''
     cis_name = ''
@@ -62,6 +63,7 @@ class IntegrationInfo:
     terraforming = False
     verbose = False
     delete = False
+    token = None
 
     # loads .env file if it exists
     def read_envfile(self, filename):
@@ -92,6 +94,39 @@ class IntegrationInfo:
             self.cis_api_key=env_vars["CIS_SERVICES_APIKEY"]
             self.api_endpoint=env_vars["API_ENDPOINT"]
     
+    def request_token(self):
+            """
+            Requests an access token for the client so that we can execute the plan and apply commands in
+            the workspace.
+            
+            param: apikey is the client's IBM Cloud Apikey
+            returns: the generated access token
+            """
+            data={'grant_type': 'urn:ibm:params:oauth:grant-type:apikey', 'apikey': self.cis_api_key}
+            headers= {'Accept': 'application/json',
+                    'Content-type': 'application/x-www-form-urlencoded',
+                    'Authorization': 'Basic Yng6Yng='}
+            url="https://iam.cloud.ibm.com/identity/token"
+            self.token = requests.post(url=url, data=data, headers=headers)
+            return self.token.json()
+
+    def get_iks_info(self, token: str):
+
+        url = "https://containers.cloud.ibm.com/global/v1/nlb-dns/clusters/" + self.cluster_id + "/list"
+
+        headers = {
+        'Accept': 'application/json',
+        'Authorization': 'Bearer ' + token
+        }
+
+        response = requests.request("GET", url, headers=headers)
+
+        print(response.text)
+
+        return response
+
+
+
     def get_crn_and_zone(self) -> bool:
         '''
         Returns the True if the cis instance information was found

--- a/src/iks.py
+++ b/src/iks.py
@@ -88,10 +88,15 @@ def iks(args):
         delete_dns.delete_dns()
 
         if UserInfo.terraforming:
-            delete_workspaces = DeleteWorkspace(UserInfo.schematics_url, UserInfo.cis_api_key)
+            delete_workspaces = DeleteWorkspace(UserInfo.schematics_url, UserInfo.cis_api_key, UserInfo.token)
             delete_workspaces.delete_workspace()
     elif UserInfo.terraforming: # handle the case of using terraform
-        work_creator = WorkspaceCreator(UserInfo.cis_api_key, UserInfo.schematics_url, UserInfo.app_url, UserInfo.cis_domain, UserInfo.resource_group, UserInfo.cis_name, UserInfo.api_endpoint, UserInfo.crn, UserInfo.zone_id, UserInfo.verbose)
+        work_creator = WorkspaceCreator(
+            UserInfo.cis_api_key, UserInfo.schematics_url, 
+            UserInfo.app_url, UserInfo.cis_domain, 
+            UserInfo.resource_group, UserInfo.cis_name, 
+            UserInfo.api_endpoint, UserInfo.crn, 
+            UserInfo.zone_id, UserInfo.verbose, UserInfo.token)
         work_creator.create_terraform_workspace()
     else:
         # handle the case of using python

--- a/src/iks.py
+++ b/src/iks.py
@@ -1,0 +1,62 @@
+from src.dns_creator import DNSCreator
+from src.create_terraform_workspace import WorkspaceCreator
+from src.functions import Color, IntegrationInfo, healthCheck
+from src.delete_dns import DeleteDNS
+from src.delete_workspaces import DeleteWorkspace
+import sys, getpass, os
+
+def print_help():
+    print(Color.BOLD + 'NAME:' + Color.END)
+    print("\tcis-integration - a command line tool used to connect a CIS instance with an application deployed on Code Engine")
+    print("\t- call this tool with either 'cis-integration' or 'ci'\n")
+
+    print("IKS VERSION: PRINT HELP NOT FINISHED")
+
+def handle_args(args):
+    if args.help:
+        print_help()
+        sys.exit(1)
+
+    UserInfo = IntegrationInfo()
+    UserInfo.terraforming = False
+    if args.terraform:
+        UserInfo.terraforming = True
+
+    if args.verbose:
+        UserInfo.verbose = True
+
+    if args.delete:
+        UserInfo.delete = True
+
+    # determining API key 
+    UserInfo.cis_api_key = getpass.getpass(prompt="Enter CIS Services API Key: ")
+    os.environ["CIS_SERVICES_APIKEY"] = UserInfo.cis_api_key
+
+    return UserInfo
+
+def iks(args):
+    UserInfo = handle_args(args)
+    if UserInfo.delete:
+        delete_dns = DeleteDNS(UserInfo.crn, UserInfo.zone_id, UserInfo.api_endpoint, UserInfo.cis_domain)
+        delete_dns.delete_dns()
+
+        if UserInfo.terraforming:
+            delete_workspaces = DeleteWorkspace(UserInfo.schematics_url, UserInfo.cis_api_key)
+            delete_workspaces.delete_workspace()
+    elif UserInfo.terraforming: # handle the case of using terraform
+        work_creator = WorkspaceCreator(UserInfo.cis_api_key, UserInfo.schematics_url, UserInfo.app_url, UserInfo.cis_domain, UserInfo.resource_group, UserInfo.cis_name, UserInfo.api_endpoint, UserInfo.crn, UserInfo.zone_id, UserInfo.verbose)
+        work_creator.create_terraform_workspace()
+    else:
+        # handle the case of using python
+        # 1. Domain Name and DNS
+        user_DNS = DNSCreator(UserInfo.crn, UserInfo.zone_id, UserInfo.api_endpoint, UserInfo.app_url)
+        user_DNS.create_records()
+        
+    if not UserInfo.delete:
+        hostUrl="https://"+UserInfo.cis_domain
+
+        healthCheck(hostUrl)
+
+        hostUrl="https://www."+UserInfo.cis_domain
+
+        healthCheck(hostUrl)

--- a/src/iks.py
+++ b/src/iks.py
@@ -33,12 +33,15 @@ def handle_args(args):
     os.environ["CIS_SERVICES_APIKEY"] = UserInfo.cis_api_key
 
     # common arguments
-    
+    UserInfo.request_token()
+
     if not UserInfo.delete:
-        UserInfo.cluster_id = args.cluster_id
-        if UserInfo.cluster_id is None:
-            print("You did not specify a IKS cluster ID.")
+        UserInfo.iks_cluster_id = args.iks_cluster_id
+        if UserInfo.iks_cluster_id is None:
+            print("You did not specify an IKS cluster ID.")
             sys.exit(1)
+
+    iks_info = UserInfo.get_iks_info()
 
     UserInfo.cis_domain = args.cis_domain
     if UserInfo.cis_domain is None:

--- a/src/iks.py
+++ b/src/iks.py
@@ -32,6 +32,50 @@ def handle_args(args):
     UserInfo.cis_api_key = getpass.getpass(prompt="Enter CIS Services API Key: ")
     os.environ["CIS_SERVICES_APIKEY"] = UserInfo.cis_api_key
 
+    # common arguments
+    
+    if not UserInfo.delete:
+        UserInfo.cluster_id = args.cluster_id
+        if UserInfo.cluster_id is None:
+            print("You did not specify a IKS cluster ID.")
+            sys.exit(1)
+
+    UserInfo.cis_domain = args.cis_domain
+    if UserInfo.cis_domain is None:
+        print("You did not specify a CIS Domain.")
+        sys.exit(1)
+    
+    # terraforming vs. not terraforming
+    if UserInfo.terraforming and not UserInfo.delete:
+        UserInfo.resource_group = args.resource_group
+        if UserInfo.resource_group is None:         
+            print("You did not specify a resource group.")
+            sys.exit(1)
+        
+        
+        UserInfo.cis_name = args.name
+        if UserInfo.cis_name is None:
+            print("You did not specify a CIS Name.")
+            sys.exit(1)
+
+        if not UserInfo.get_crn_and_zone():
+                print("Failed to retrieve CRN and Zone ID. Check the name of your CIS instance and try again")
+                sys.exit(1)
+        
+    else:
+        UserInfo.crn=args.crn
+        UserInfo.zone_id = args.zone_id
+        if UserInfo.crn is None or UserInfo.zone_id is None:
+            UserInfo.cis_name = args.name
+        
+            if UserInfo.cis_name is None:
+                print("Please specify the name of your CIS instance or both the CIS CRN and CIS Zone ID")
+                sys.exit(1)
+
+            if not UserInfo.get_crn_and_zone():
+                print("Failed to retrieve CRN and Zone ID. Check the name of your CIS instance and try again")
+                sys.exit(1)
+
     return UserInfo
 
 def iks(args):

--- a/src/main.py
+++ b/src/main.py
@@ -38,9 +38,15 @@ def main():
     #created iks sub-command as an example for to structure the next platform
     ks_parser = subparsers.add_parser("iks", aliases=['ks'], add_help=False)
     ks_parser.add_argument("-h","--help", action="store_true")
-    ks_parser.add_argument("-a")
-    ks_parser.add_argument("-b")
-    ks_parser.add_argument("-c")
+    ks_parser.add_argument("-c","--crn")
+    ks_parser.add_argument("-z","--zone_id")
+    ks_parser.add_argument("-d","--cis_domain")
+    ks_parser.add_argument("-t","--terraform", action='store_true')
+    ks_parser.add_argument("-r","--resource_group")
+    ks_parser.add_argument("-n","--name")
+    ks_parser.add_argument("-v","--verbose", action='store_true')
+    ks_parser.add_argument("--delete", action='store_true')
+    ks_parser.add_argument("-i","--iks_cluster_id")
 
     args = parser.parse_args()
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import os
 import sys
 import argparse
 from src.codeEngine import CodeEngine
+from src.iks import iks
 import subprocess
 
 def execute(cmd):
@@ -60,6 +61,7 @@ def main():
 
     elif args.command=="iks" or args.command=="ks":
         print("running iks command")
+        iks(args)
 
 if __name__ == "__main__":
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -37,6 +37,7 @@ def main():
 
     #created iks sub-command as an example for to structure the next platform
     ks_parser = subparsers.add_parser("iks", aliases=['ks'], add_help=False)
+    ks_parser.add_argument("-h","--help", action="store_true")
     ks_parser.add_argument("-a")
     ks_parser.add_argument("-b")
     ks_parser.add_argument("-c")

--- a/tests/test_edge_functions.py
+++ b/tests/test_edge_functions.py
@@ -15,12 +15,12 @@ class MockResponse:
 
 # custom class to be a mock token
 # will override request token
-class MockToken:
+#class MockToken:
 
     # mock token() method always returns a specific access token
-    @staticmethod
-    def token(self, dummy):
-        return "test-token"
+    #@staticmethod
+    #def token(self, dummy):
+        #return "test-token"
 
 def edge_function():
     return create_edge_function.EdgeFunctionCreator(
@@ -28,7 +28,8 @@ def edge_function():
         app_url="test-url.com",
         apikey="testString",
         zone_id="testString",
-        domain="test-domain.com"
+        domain="test-domain.com",
+        token="test-token"
     )
 
 def test_create_edge_action(monkeypatch):
@@ -38,12 +39,12 @@ def test_create_edge_action(monkeypatch):
     def mock_put(*args, **kwargs):
         return MockResponse()
 
-    def mock_token(*args, **kwargs):
-        return MockToken()
+    #def mock_token(*args, **kwargs):
+    #    return MockToken()
 
     # apply the monkeypatch for requests.get to mock_get
     monkeypatch.setattr(requests, "request", mock_put)
-    monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
+    #monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
 
     # app.get_json, which contains requests.get, uses the monkeypatch
     test_edge_function = edge_function()
@@ -56,12 +57,12 @@ def test_create_edge_trigger(monkeypatch):
     def mock_put(*args, **kwargs):
         return MockResponse()
 
-    def mock_token(*args, **kwargs):
-        return MockToken()
+    #def mock_token(*args, **kwargs):
+    #    return MockToken()
 
     # apply the monkeypatch for requests.get to mock_get
     monkeypatch.setattr(requests, "request", mock_put)
-    monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
+    #monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
 
     # app.get_json, which contains requests.get, uses the monkeypatch
     test_edge_function = edge_function()
@@ -74,12 +75,12 @@ def test_create_edge_www_trigger(monkeypatch):
     def mock_put(*args, **kwargs):
         return MockResponse()
 
-    def mock_token(*args, **kwargs):
-        return MockToken()
+    #def mock_token(*args, **kwargs):
+    #    return MockToken()
 
     # apply the monkeypatch for requests.get to mock_get
     monkeypatch.setattr(requests, "request", mock_put)
-    monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
+    #monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
 
     # app.get_json, which contains requests.get, uses the monkeypatch
     test_edge_function = edge_function()
@@ -92,12 +93,12 @@ def test_create_edge_wild_card_trigger(monkeypatch):
     def mock_put(*args, **kwargs):
         return MockResponse()
 
-    def mock_token(*args, **kwargs):
-        return MockToken()
+    #def mock_token(*args, **kwargs):
+    #    return MockToken()
 
     # apply the monkeypatch for requests.get to mock_get
     monkeypatch.setattr(requests, "request", mock_put)
-    monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
+    #monkeypatch.setattr(create_edge_function.EdgeFunctionCreator, "request_token", mock_token().token)
 
     # app.get_json, which contains requests.get, uses the monkeypatch
     test_edge_function = edge_function()


### PR DESCRIPTION
Added a skeleton structure for the IKS version of the CLI tool. It currently only creates the DNS records running the python version right now.

To create the DNS records, the user inputs the cluster ID of their IKS instance. Using the cluster ID, we can retrieve the ingress subdomain tied to the IKS instance, which is used to create the DNS records.