### PR TITLE
Creating Certificates as Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Regardless of the option you choose, the tool will require you to input some inf
 3. If you're using Docker, build and run your Docker image with the above commands
 4. Input the following generic command:
 ```
-$ cis-integration code-engine -n [CIS NAME] -d [CIS DOMAIN] -a [CODE ENGINE APP DOMAIN]
+$ cis-integration code-engine -n [CIS NAME] -r [RESOURCE GROUP] -d [CIS DOMAIN] -a [CODE ENGINE APP DOMAIN]
 ```
 An alternative command is also available:
 ```
@@ -76,6 +76,7 @@ $ cis-integration code-engine -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [
 ```
 ### Arguments:
 * **CIS NAME:** the name of your CIS instance.
+* **RESOURCE GROUP:** the resource group connected to the CIS instance. Found by navigating to your CIS resource page and clicking on "Details".
 * **CIS CRN:** the cloud resource name (CRN) of your CIS instance. Found in the "Overview" tab of your CIS resource page. 
     Example: `crn:v1:test:public:internet-svcs:global:a/2c38d9a9913332006a27665dab3d26e8:836f33a5-d3e1-4bc6-876a-982a8668b1bb::`
 * **CIS ID:** the ID associated with your CIS instance. Found in the "Overview" tab of your CIS resource page under "Domain ID". 
@@ -123,7 +124,7 @@ cis-integration code-engine --env
 ### Deleting created resources with the `--delete` option
 If you decide to delete the resources you've created using this tool, the `--delete` global option is available to you. The global load balancer, origin pool, health check, DNS records, TLS certificate(s), edge function, and (by adding --terraform to the command) the Schematics workspace(s) created by this tool may be deleted. Use the following generic examples to format the command:
 ```
-cis-integration code-engine --delete -n [CIS NAME] -d [CIS DOMAIN]
+cis-integration code-engine --delete -n [CIS NAME] -r [RESOURCE GROUP] -d [CIS DOMAIN]
 ```
 or
 ```

--- a/main.py.egg-info/SOURCES.txt
+++ b/main.py.egg-info/SOURCES.txt
@@ -1,3 +1,4 @@
+LICENSE
 README.md
 setup.py
 main.py.egg-info/PKG-INFO
@@ -7,10 +8,17 @@ main.py.egg-info/entry_points.txt
 main.py.egg-info/top_level.txt
 src/__init__.py
 src/certcreate.py
+src/certcreate_iks.py
 src/codeEngine.py
 src/create_edge_function.py
 src/create_glb.py
 src/create_terraform_workspace.py
+src/delete_certs.py
+src/delete_dns.py
+src/delete_edge.py
+src/delete_glb.py
+src/delete_workspaces.py
 src/dns_creator.py
 src/functions.py
+src/iks.py
 src/main.py

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -1,0 +1,50 @@
+import requests, json
+from src.functions import Color as Color
+
+class SecretCertificateCreator:
+
+    def __init__(self, cluster_id, cert_manager_crn, cert_name, apikey):
+        self.cluster_id = cluster_id
+        self.cert_manager_crn = cert_manager_crn
+        self.cert_name = cert_name
+        self.apikey = apikey
+        self.token = self.request_token(self.apikey)
+
+    def create_certificate(self):
+        print("hello")
+        cert_url = "https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret"
+        
+        # Creating the data required for the request
+        cert_data = json.dumps({
+            "cluster": self.cluster_id,
+            "crn": self.cert_manager_crn,
+            "name": self.cert_name,
+            "namespace": "default",
+            "persistence": True
+        })
+
+        # Creating the headers required for the request
+        cert_headers = {
+            "Content-Type": 'application/json',
+            "Accept": 'application/json',
+            "Authorization": 'Bearer ' + self.token
+        }
+
+        cert_response = requests.request("POST", url=cert_url, headers=cert_headers, data=cert_data)
+        return cert_response
+    
+    def request_token(self, apikey: str):
+        """
+        Requests an access token for the client so that we can execute the plan and apply commands in
+        the workspace.
+        
+        param: apikey is the client's IBM Cloud Apikey
+        returns: the generated access token
+        """
+        data={'grant_type': 'urn:ibm:params:oauth:grant-type:apikey', 'apikey': apikey}
+        headers= {'Accept': 'application/json',
+                'Content-type': 'application/x-www-form-urlencoded',
+                'Authorization': 'Basic Yng6Yng='}
+        url="https://iam.cloud.ibm.com/identity/token"
+        token = requests.post(url=url, data=data, headers=headers)
+        return token.json()["access_token"]

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -51,19 +51,20 @@ class SecretCertificateCreator:
             exit(1)
 
         cert_check_url = f"https://{region}.certificate-manager.cloud.ibm.com/api/v3/{url_cert_man_crn}/certificates/"
-
+        print(cert_check_url)
         cert_check_headers = {
             "Authorization": 'Bearer ' + self.token
         }
 
         # Gets all certificates previously present in the certificate manager
         cert_check_response = requests.request("GET", url=cert_check_url, headers=cert_check_headers)
-        
+        #print(cert_check_response.text)
         # If a valid certificate exists, it returns the CRN of that certificate
-        for cert in cert_check_response.json()["certificates"]:
-            if self.cis_domain in cert["domains"] and ("*." + self.cis_domain) in cert["domains"]:
-                print("Certificate with domain already exists in certificate manager")
-                return cert["_id"]
+        if cert_check_response.status_code == 200:
+            for cert in cert_check_response.json()["certificates"]:
+                if self.cis_domain in cert["domains"] and ("*." + self.cis_domain) in cert["domains"]:
+                    print("Certificate with domain already exists in certificate manager")
+                    return cert["_id"]
         
         print("Ordering a certificate for the certificate manager...")
 
@@ -83,7 +84,8 @@ class SecretCertificateCreator:
 
         # Orders a new certificate through the certificate manager
         cert_create_response = requests.request("POST", url=cert_create_url, headers=cert_create_headers, data=cert_create_data)
-
+        print(cert_create_response)
+        print(cert_create_response.text)
         # Returns the CRN of the new certificate
         print(Color.GREEN+"SUCESS: Ordered a certificate for the certificate manager!"+Color.END)
         return cert_create_response.json()["_id"]

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -32,9 +32,9 @@ class SecretCertificateCreator:
         cert_response = requests.request("POST", url=cert_url, headers=cert_headers, data=cert_data)
         
         if cert_response.status_code == 200:
-            print(Color.GREEN+"SUCCESS: Created TLS certificate for IKS"+Color.END)
+            print(Color.GREEN+"SUCCESS: Created secret for IKS"+Color.END)
         else:
-            print(Color.RED+"ERROR: Failed to create TLS certificate for IKS with error code " + str(cert_response.status_code) + Color.END)
+            print(Color.RED+"ERROR: Failed to create secret for IKS with error code " + str(cert_response.status_code) + Color.END)
 
         return cert_response
     

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -3,14 +3,15 @@ from src.functions import Color as Color
 
 class SecretCertificateCreator:
 
-    def __init__(self, cluster_id, cert_manager_crn, cert_name, apikey, token):
+    def __init__(self, cis_crn, cluster_id, cis_domain, cert_manager_crn, cert_name, token):
+        self.cis_crn = cis_crn
         self.cluster_id = cluster_id
+        self.cis_domain = cis_domain
         self.cert_manager_crn = cert_manager_crn
         self.cert_name = cert_name
-        self.apikey = apikey
         self.token = token
 
-    def create_certificate(self):
+    def create_secret(self):
         cert_url = "https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret"
         
         # Creating the data required for the request
@@ -37,24 +38,47 @@ class SecretCertificateCreator:
             print(Color.RED+"ERROR: Failed to create secret for IKS with error code " + str(cert_response.status_code) + Color.END)
 
         return cert_response
-    
-    '''
-    def request_token(self, apikey: str):
-        """
-        Requests an access token for the client so that we can execute the plan and apply commands in
-        the workspace.
+
+    def check_certificate(self):
+        url_cert_man_crn = self.URLify(self.cert_manager_crn)
+        try:
+            region = self.cert_manager_crn.split(":")[5]
+        except:
+            print(Color.RED+"ERROR: CRN provided not in correct format"+Color.END)
+            exit(1)
+
+        cert_check_url = f"https://{region}.certificate-manager.cloud.ibm.com/api/v3/{url_cert_man_crn}/certificates/"
+
+        cert_check_headers = {
+            "Authorization": 'Bearer ' + self.token
+        }
+
+        cert_check_response = requests.request("GET", url=cert_check_url, headers=cert_check_headers)
+        for cert in cert_check_response.json()["certificates"]:
+            if self.cis_domain in cert["domains"] and ("*." + self.cis_domain) in cert["domains"]:
+                print("Certificate with domain already exists in certificate manager")
+                return cert["_id"]
         
-        param: apikey is the client's IBM Cloud Apikey
-        returns: the generated access token
-        """
-        data={'grant_type': 'urn:ibm:params:oauth:grant-type:apikey', 'apikey': apikey}
-        headers= {'Accept': 'application/json',
-                'Content-type': 'application/x-www-form-urlencoded',
-                'Authorization': 'Basic Yng6Yng='}
-        url="https://iam.cloud.ibm.com/identity/token"
-        token = requests.post(url=url, data=data, headers=headers)
-        return token.json()["access_token"]
-    '''
+        print("Ordering a certificate for the certificate manager...")
+
+        cert_create_url = f"https://{region}.certificate-manager.cloud.ibm.com/api/v1/{url_cert_man_crn}/certificates/order"
+
+        cert_create_data = json.dumps({
+            "name": self.cert_name,
+            "domains": [self.cis_domain, "*."+self.cis_domain],
+            "dns_provider_instance_crn": self.cis_crn
+        })
+
+        cert_create_headers = {
+            "Content-Type": 'application/json',
+            "authorization": 'Bearer ' + self.token
+        }
+
+        cert_create_response = requests.request("POST", url=cert_create_url, headers=cert_create_headers, data=cert_create_data)
+       
+        print(Color.GREEN+"SUCESS: Ordered a certificate for the certificate manager!"+Color.END)
+        return cert_create_response.json()["_id"]
+        
 
     def URLify(self, replacement_str):
         new_string = replacement_str.replace(":", "%3A")

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -11,7 +11,6 @@ class SecretCertificateCreator:
         self.token = self.request_token(self.apikey)
 
     def create_certificate(self):
-        print("hello")
         cert_url = "https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret"
         
         # Creating the data required for the request
@@ -31,6 +30,12 @@ class SecretCertificateCreator:
         }
 
         cert_response = requests.request("POST", url=cert_url, headers=cert_headers, data=cert_data)
+        
+        if cert_response.status_code == 200:
+            print(Color.GREEN+"SUCCESS: Created TLS certificate for IKS"+Color.END)
+        else:
+            print(Color.RED+"ERROR: Failed to create TLS certificate for IKS with error code " + str(cert_response.status_code) + Color.END)
+
         return cert_response
     
     def request_token(self, apikey: str):

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -1,4 +1,4 @@
-import requests, json
+import requests, json, time
 from src.functions import Color as Color
 
 class SecretCertificateCreator:
@@ -31,13 +31,21 @@ class SecretCertificateCreator:
             "Accept": 'application/json',
             "Authorization": 'Bearer ' + self.token
         }
+        keepgoing = True
 
-        cert_response = requests.request("POST", url=cert_url, headers=cert_headers, data=cert_data)
-        
-        if cert_response.status_code == 200:
-            print(Color.GREEN+"SUCCESS: Created secret for IKS"+Color.END)
-        else:
-            print(Color.RED+"ERROR: Failed to create secret for IKS with error code " + str(cert_response.status_code) + Color.END)
+        while keepgoing:
+            cert_response = requests.request("POST", url=cert_url, headers=cert_headers, data=cert_data)
+            
+            if cert_response.status_code == 200:
+                print(Color.GREEN+"SUCCESS: Created secret for IKS"+Color.END)
+                keepgoing = False
+            elif cert_response.status_code == 500:
+                print("Waiting for a response from the certificate manager...")
+                print(cert_response.json())
+                time.sleep(2)
+            else:
+                print(Color.RED+"ERROR: Failed to create secret for IKS with error code " + str(cert_response.status_code) + Color.END)
+                keepgoing = False
 
         return cert_response
 
@@ -87,7 +95,7 @@ class SecretCertificateCreator:
         print(cert_create_response)
         print(cert_create_response.text)
         # Returns the CRN of the new certificate
-        print(Color.GREEN+"SUCESS: Ordered a certificate for the certificate manager!"+Color.END)
+        print(Color.GREEN+"SUCCESS: Ordered a certificate for the certificate manager!"+Color.END)
         return cert_create_response.json()["_id"]
         
     # Converts the certificate manager CRN into a URL-encoded CRN

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -55,3 +55,7 @@ class SecretCertificateCreator:
         token = requests.post(url=url, data=data, headers=headers)
         return token.json()["access_token"]
     '''
+
+    def URLify(self, replacement_str):
+        new_string = replacement_str.replace(":", "%3A")
+        return new_string.replace("/", "%2F")

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -11,13 +11,15 @@ class SecretCertificateCreator:
         self.cert_name = cert_name
         self.token = token
 
+    # Creates a secret in the IKS cluster using the CRN returned by check_certificate()
     def create_secret(self):
+        cert_crn = self.check_certificate()
         cert_url = "https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret"
         
         # Creating the data required for the request
         cert_data = json.dumps({
             "cluster": self.cluster_id,
-            "crn": self.cert_manager_crn,
+            "crn": cert_crn,
             "name": self.cert_name,
             "namespace": "default",
             "persistence": True
@@ -39,6 +41,7 @@ class SecretCertificateCreator:
 
         return cert_response
 
+    # Creates a certificate (if necessary) and returns a CRN
     def check_certificate(self):
         url_cert_man_crn = self.URLify(self.cert_manager_crn)
         try:
@@ -53,7 +56,10 @@ class SecretCertificateCreator:
             "Authorization": 'Bearer ' + self.token
         }
 
+        # Gets all certificates previously present in the certificate manager
         cert_check_response = requests.request("GET", url=cert_check_url, headers=cert_check_headers)
+        
+        # If a valid certificate exists, it returns the CRN of that certificate
         for cert in cert_check_response.json()["certificates"]:
             if self.cis_domain in cert["domains"] and ("*." + self.cis_domain) in cert["domains"]:
                 print("Certificate with domain already exists in certificate manager")
@@ -66,7 +72,8 @@ class SecretCertificateCreator:
         cert_create_data = json.dumps({
             "name": self.cert_name,
             "domains": [self.cis_domain, "*."+self.cis_domain],
-            "dns_provider_instance_crn": self.cis_crn
+            "dns_provider_instance_crn": self.cis_crn,
+            "auto_renew_enabled": True
         })
 
         cert_create_headers = {
@@ -74,12 +81,14 @@ class SecretCertificateCreator:
             "authorization": 'Bearer ' + self.token
         }
 
+        # Orders a new certificate through the certificate manager
         cert_create_response = requests.request("POST", url=cert_create_url, headers=cert_create_headers, data=cert_create_data)
-       
+
+        # Returns the CRN of the new certificate
         print(Color.GREEN+"SUCESS: Ordered a certificate for the certificate manager!"+Color.END)
         return cert_create_response.json()["_id"]
         
-
+    # Converts the certificate manager CRN into a URL-encoded CRN
     def URLify(self, replacement_str):
         new_string = replacement_str.replace(":", "%3A")
         return new_string.replace("/", "%2F")

--- a/src/certcreate_iks.py
+++ b/src/certcreate_iks.py
@@ -3,12 +3,12 @@ from src.functions import Color as Color
 
 class SecretCertificateCreator:
 
-    def __init__(self, cluster_id, cert_manager_crn, cert_name, apikey):
+    def __init__(self, cluster_id, cert_manager_crn, cert_name, apikey, token):
         self.cluster_id = cluster_id
         self.cert_manager_crn = cert_manager_crn
         self.cert_name = cert_name
         self.apikey = apikey
-        self.token = self.request_token(self.apikey)
+        self.token = token
 
     def create_certificate(self):
         cert_url = "https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret"
@@ -38,6 +38,7 @@ class SecretCertificateCreator:
 
         return cert_response
     
+    '''
     def request_token(self, apikey: str):
         """
         Requests an access token for the client so that we can execute the plan and apply commands in
@@ -53,3 +54,4 @@ class SecretCertificateCreator:
         url="https://iam.cloud.ibm.com/identity/token"
         token = requests.post(url=url, data=data, headers=headers)
         return token.json()["access_token"]
+    '''

--- a/src/codeEngine.py
+++ b/src/codeEngine.py
@@ -29,10 +29,10 @@ def print_help():
     print("\t- call this tool with either 'cis-integration' or 'ci'\n")
 
     print(Color.BOLD + "USAGE:" + Color.END)
-    print("\t[python command]\t\tcis-integration [positional args] [global options] -n [CIS NAME] -d [CIS DOMAIN] -a [APP DOMAIN]")
+    print("\t[python command]\t\tcis-integration [positional args] [global options] -n [CIS NAME] -r [RESOURCE GROUP] -d [CIS DOMAIN] -a [APP DOMAIN]")
     print("\t[alt python command]\t\tcis-integration [positional args] [global options] -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN] -a [APP DOMAIN] \n")
     print("\t[terraform command]\t\tcis-integration [positional args] [global options] --terraform -r [RESOURCE GROUP] -n [CIS NAME] -d [CIS DOMAIN] -a [APP DOMAIN]\n")
-    print("\t[delete command]\t\tcis-integration [positional args] [global options] --delete -n [CIS NAME] -d [CIS DOMAIN]")
+    print("\t[delete command]\t\tcis-integration [positional args] [global options] --delete -n [CIS NAME] -r [RESOURCE GROUP] -d [CIS DOMAIN]")
     print("\t[alt delete command]\t\tcis-integration [positional args] [global options] --delete -c [CIS CRN] -z [CIS ZONE ID] -d [CIS DOMAIN]\n")
 
     print(Color.BOLD + "POSITIONAL ARGUMENTS:" + Color.END)

--- a/src/codeEngine.py
+++ b/src/codeEngine.py
@@ -100,6 +100,7 @@ def handle_args(args):
             print("You did not specify a resource group.")
             sys.exit(1)
         
+        UserInfo.get_resource_id()
         
         UserInfo.cis_name = args.name
         if UserInfo.cis_name is None:
@@ -114,6 +115,14 @@ def handle_args(args):
         UserInfo.crn=args.crn
         UserInfo.zone_id = args.zone_id
         if UserInfo.crn is None or UserInfo.zone_id is None:
+
+            UserInfo.resource_group = args.resource_group
+            if UserInfo.resource_group is None:         
+                print("You did not specify a resource group.")
+                sys.exit(1)
+
+            UserInfo.get_resource_id()
+
             UserInfo.cis_name = args.name
         
             if UserInfo.cis_name is None:

--- a/src/functions.py
+++ b/src/functions.py
@@ -133,6 +133,7 @@ class IntegrationInfo:
         manager = ResourceManagerV2(authenticator=authenticator)
         resource = manager.list_resource_groups(name=self.resource_group, include_deleted=False).get_result()
         self.resource_id = resource["resources"][0]["id"]
+        print(self.resource_id)
 
     def get_cms(self):
         authenticator = IAMAuthenticator(self.cis_api_key)

--- a/src/functions.py
+++ b/src/functions.py
@@ -138,7 +138,7 @@ class IntegrationInfo:
     def get_cms(self):
         authenticator = IAMAuthenticator(self.cis_api_key)
         controller = ResourceControllerV2(authenticator=authenticator)
-        resource_list = controller.list_resource_instances(name="kube-"+self.iks_cluster_id, resource_group_id=self.resource_id).get_result()
+        resource_list = controller.list_resource_instances(name="kube-certmgr-"+self.iks_cluster_id, resource_group_id=self.resource_id).get_result()
         print(resource_list)
         return resource_list["resources"][0]["id"]
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -138,7 +138,8 @@ class IntegrationInfo:
     def get_cms(self):
         authenticator = IAMAuthenticator(self.cis_api_key)
         controller = ResourceControllerV2(authenticator=authenticator)
-        resource_list = controller.list_resource_instances(name="kube-"+self.iks_cluster_id, resource_group_id=self.resource_group).get_result()
+        resource_list = controller.list_resource_instances(name="kube-"+self.iks_cluster_id, resource_group_id=self.resource_id).get_result()
+        print(resource_list)
         return resource_list["resources"][0]["id"]
 
     def get_crn_and_zone(self) -> bool:

--- a/src/functions.py
+++ b/src/functions.py
@@ -1,6 +1,7 @@
+from ibm_platform_services.case_management_v1 import Resource
 import requests
 import sys
-from ibm_platform_services import ResourceControllerV2
+from ibm_platform_services import ResourceControllerV2, ResourceManagerV2
 from ibm_cloud_networking_services import ZonesV1
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
@@ -56,6 +57,7 @@ class IntegrationInfo:
     iks_cluster_id = ''
     app_url = ''
     resource_group = ''
+    resource_id = ''
     cis_name = ''
     cis_api_key = ''
     cis_domain = ''
@@ -126,7 +128,17 @@ class IntegrationInfo:
                 self.app_url = cluster["nlbHost"]
         return response
 
+    def get_resource_id(self):
+        authenticator = IAMAuthenticator(self.cis_api_key)
+        manager = ResourceManagerV2(authenticator=authenticator)
+        resource = manager.list_resource_groups(name=self.resource_group, include_deleted=False).get_result()
+        self.resource_id = resource["resources"][0]["id"]
 
+    def get_cms(self):
+        authenticator = IAMAuthenticator(self.cis_api_key)
+        controller = ResourceControllerV2(authenticator=authenticator)
+        resource_list = controller.list_resource_instances(name="kube-"+self.iks_cluster_id, resource_group_id=self.resource_group).get_result()
+        return resource_list["resources"][0]["id"]
 
     def get_crn_and_zone(self) -> bool:
         '''
@@ -134,7 +146,7 @@ class IntegrationInfo:
         '''
         authenticator = IAMAuthenticator(self.cis_api_key)
         controller = ResourceControllerV2(authenticator=authenticator)
-        resource_list = controller.list_resource_instances(name=self.cis_name, type="service_instance").get_result()
+        resource_list = controller.list_resource_instances(name=self.cis_name, resource_group_id=self.resource_id, type="service_instance").get_result()
         if len(resource_list["resources"]) > 0:
             for resource in resource_list["resources"]:
                 if resource["name"] == self.cis_name:

--- a/src/iks-terraform/cert.tf
+++ b/src/iks-terraform/cert.tf
@@ -1,0 +1,45 @@
+data "ibm_resource_instance" "cm" {
+  name              = "kube-certmgr-${var.cluster_id}"
+  resource_group_id = data.ibm_resource_group.group.id
+  service           = "cloudcerts"
+}
+
+data ibm_resource_group group {
+  name = var.resource_group
+}
+
+data ibm_cis_domain cis_instance_domain {
+  domain = var.cis_domain
+  cis_id = data.ibm_cis.cis_instance.id
+}
+
+data ibm_cis cis_instance {
+  name              = var.cis_name
+  resource_group_id = data.ibm_resource_group.group.id
+
+resource "ibm_certificate_manager_order" "cert" {
+  certificate_manager_instance_id = data.ibm_resource_instance.cm.id
+  name                            = "test"
+  description                     = "test description"
+  domains                         = [var.cis_domain, "*.${var.cis_domain}"]
+  dns_provider_instance_crn       = data.ibm_cis.cis_instance.id
+  auto_renew_enabled              = true
+}
+
+resource null_resource create_cert_secret_via_api {
+
+    provisioner local-exec {
+        command = <<BASH
+curl -X POST https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret \
+    -H "Authorization: ${var.token}" \
+    -d '{
+        "cluster" : "${var.cluster_id}",
+        "crn" : "${ibm_certificate_manager_order.cert.id}",
+        "name" : "cis-cert",
+        "namespace" : "default",
+        "persistence" : true
+    }'
+        BASH 
+    }
+    
+}

--- a/src/iks-terraform/cert.tf
+++ b/src/iks-terraform/cert.tf
@@ -17,6 +17,8 @@ data ibm_cis cis_instance {
   name              = var.cis_name
   resource_group_id = data.ibm_resource_group.group.id
 
+data ibm_iam_auth_token token {}
+
 resource "ibm_certificate_manager_order" "cert" {
   certificate_manager_instance_id = data.ibm_resource_instance.cm.id
   name                            = "test"
@@ -31,7 +33,7 @@ resource null_resource create_cert_secret_via_api {
     provisioner local-exec {
         command = <<BASH
 curl -X POST https://containers.cloud.ibm.com/global/ingress/v2/secret/createSecret \
-    -H "Authorization: ${var.token}" \
+    -H "Authorization: ${data.ibm_iam_auth_token.token.iam_access_token}" \
     -d '{
         "cluster" : "${var.cluster_id}",
         "crn" : "${ibm_certificate_manager_order.cert.id}",

--- a/src/iks-terraform/provider.tf
+++ b/src/iks-terraform/provider.tf
@@ -1,0 +1,11 @@
+provider ibm {
+    ibmcloud_api_key = var.ibmcloud_api_key
+}
+
+terraform {
+    required_providers {
+        ibm = {
+            source = "IBM-Cloud/ibm"
+        }
+    }
+}

--- a/src/iks-terraform/variables.tf
+++ b/src/iks-terraform/variables.tf
@@ -35,8 +35,3 @@ variable cluster_id {
     type = string
     description = "Cluster ID of the IKS instance"
 }
-
-variable token {
-    type = string
-    description = "IAM Authorization token"
-}

--- a/src/iks-terraform/variables.tf
+++ b/src/iks-terraform/variables.tf
@@ -1,0 +1,42 @@
+variable ibmcloud_api_key {
+    type = string
+    description = "Unique API Key to verify access permissions"
+    validation {
+    # regex(...) fails if it cannot find a match
+    condition     = length(var.ibmcloud_api_key)==44
+    error_message = "This is not a valid API key."
+  }
+}
+variable cis_name {
+    type = string
+    description = "Name of the CIS instance"
+  validation {
+      condition = can(regex("^([^[:ascii:]]|[a-zA-Z0-9-._: ])+$", var.cis_name))
+      error_message = "Not a valid CIS Name."
+  }
+}
+
+variable resource_group {
+    type = string
+    description = "Name of the group the resource was created under"
+}
+
+variable cis_domain {
+    type = string
+    description = "Domain name that you want to be attached to the CIS Instance and Code Engine app"
+    validation {
+    # regex(...) fails if it cannot find a match
+    condition     = can(regex("^([^[:ascii:]]|[a-zA-Z0-9-._: ])+$", var.cis_domain))
+    error_message = "This is not a valid domain name for the CIS Instance."
+  }
+}
+
+variable cluster_id {
+    type = string
+    description = "Cluster ID of the IKS instance"
+}
+
+variable token {
+    type = string
+    description = "IAM Authorization token"
+}

--- a/src/iks.py
+++ b/src/iks.py
@@ -112,6 +112,8 @@ def iks(args):
         # 1. Domain Name and DNS
         user_DNS = DNSCreator(UserInfo.crn, UserInfo.zone_id, UserInfo.api_endpoint, UserInfo.app_url)
         user_DNS.create_records()
+        # 2. Generate certificate in manager if necessary
+        
 
         
         

--- a/src/iks.py
+++ b/src/iks.py
@@ -120,7 +120,6 @@ def iks(args):
             cluster_id=UserInfo.iks_cluster_id, 
             cis_domain=UserInfo.cis_domain, 
             cert_manager_crn=cms_id,
-            cert_name="cis-cert",
             token=UserInfo.token["access_token"]
             )
         user_cert.create_secret()

--- a/src/iks.py
+++ b/src/iks.py
@@ -1,3 +1,4 @@
+from src.certcreate_iks import SecretCertificateCreator
 from src.dns_creator import DNSCreator
 from src.create_terraform_workspace import WorkspaceCreator
 from src.functions import Color, IntegrationInfo, healthCheck
@@ -107,12 +108,23 @@ def iks(args):
             UserInfo.zone_id, UserInfo.verbose, UserInfo.token)
         work_creator.create_terraform_workspace()
     else:
-        print(UserInfo.get_cms())
         # handle the case of using python
         # 1. Domain Name and DNS
         user_DNS = DNSCreator(UserInfo.crn, UserInfo.zone_id, UserInfo.api_endpoint, UserInfo.app_url)
         user_DNS.create_records()
         # 2. Generate certificate in manager if necessary
+        cms_id = UserInfo.get_cms()
+        print("\n"+cms_id)
+        user_cert = SecretCertificateCreator(
+            cis_crn=UserInfo.crn, 
+            cluster_id=UserInfo.iks_cluster_id, 
+            cis_domain=UserInfo.cis_domain, 
+            cert_manager_crn=cms_id,
+            cert_name="cis-cert",
+            token=UserInfo.token["access_token"]
+            )
+        user_cert.create_secret()
+
         
 
         

--- a/src/iks.py
+++ b/src/iks.py
@@ -107,10 +107,13 @@ def iks(args):
             UserInfo.zone_id, UserInfo.verbose, UserInfo.token)
         work_creator.create_terraform_workspace()
     else:
+        print(UserInfo.get_cms())
         # handle the case of using python
         # 1. Domain Name and DNS
         user_DNS = DNSCreator(UserInfo.crn, UserInfo.zone_id, UserInfo.api_endpoint, UserInfo.app_url)
         user_DNS.create_records()
+
+        
         
     if not UserInfo.delete:
         hostUrl="https://"+UserInfo.cis_domain

--- a/src/iks.py
+++ b/src/iks.py
@@ -55,6 +55,7 @@ def handle_args(args):
             print("You did not specify a resource group.")
             sys.exit(1)
         
+        UserInfo.get_resource_id()
         
         UserInfo.cis_name = args.name
         if UserInfo.cis_name is None:
@@ -66,6 +67,13 @@ def handle_args(args):
                 sys.exit(1)
         
     else:
+        UserInfo.resource_group = args.resource_group
+        if UserInfo.resource_group is None:         
+            print("You did not specify a resource group.")
+            sys.exit(1)
+
+        UserInfo.get_resource_id()
+
         UserInfo.crn=args.crn
         UserInfo.zone_id = args.zone_id
         if UserInfo.crn is None or UserInfo.zone_id is None:

--- a/src/main.py
+++ b/src/main.py
@@ -37,13 +37,13 @@ def main():
 
     #created iks sub-command as an example for to structure the next platform
     ks_parser = subparsers.add_parser("iks", aliases=['ks'], add_help=False)
-    ks_parser.add_argument("-h","--help", action="store_true")
     ks_parser.add_argument("-c","--crn")
     ks_parser.add_argument("-z","--zone_id")
     ks_parser.add_argument("-d","--cis_domain")
     ks_parser.add_argument("-t","--terraform", action='store_true')
     ks_parser.add_argument("-r","--resource_group")
     ks_parser.add_argument("-n","--name")
+    ks_parser.add_argument("-h","--help", action='store_true')
     ks_parser.add_argument("-v","--verbose", action='store_true')
     ks_parser.add_argument("--delete", action='store_true')
     ks_parser.add_argument("-i","--iks_cluster_id")


### PR DESCRIPTION
This pull request introduces the capability to create certificates as part of the secrets of our cluster. It pulls the CRN from the Certificate Manager created by the user and uses that as well as the ID of the necessary cluster to import the certificate into the cluster as a secret in preparation for IKS integration.