### PR TITLE
updates to install and added try block to catch any exceptions during uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 export PYTHONPATH=$PYTHONPATH:/usr/local/bin
 pip3 install -r requirements.txt
-pip3 install -e . --target /usr/local/bin
+pip3 install -e . --target /usr/local/bin --upgrade
 python3 install_check.py

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 export PYTHONPATH=$PYTHONPATH:/usr/local/bin
 pip3 install -r requirements.txt
-python3 setup.py develop --install-dir /usr/local/bin
+pip3 install -e . --target /usr/local/bin
 python3 install_check.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cffi==1.14.5
 cfgv==3.3.0
 chardet==4.0.0
 cryptography==3.4.7
-detect-secrets @ git+https://github.com/ibm/detect-secrets.git@706ee1d2d03a45f105ed9d906fb10881f48726d1
 distlib==0.3.2
 filelock==3.0.12
 ibm-cloud-networking-services==0.6.0

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ def execute(cmd):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-u", "--uninstall", help="uninstalls cis-integration from your system", action="store_true",)
+    parser.add_argument("-s", "--sudo", help="adds sudo privileges for uninstall process", action="store_true",)
 
     subparsers = parser.add_subparsers(dest="command")
     
@@ -47,10 +48,17 @@ def main():
         confirm = input("Are you sure you wish to uninstall? (y/n): ").lower()
         if confirm == 'y' or confirm == 'yes':
             try:
-                bash_cmd = "pip3 uninstall -y -r requirements.txt"
+                bash_cmd = ""
+                if args.sudo:
+                    bash_cmd = "sudo pip3 uninstall -y -r requirements.txt"
+                else:
+                    bash_cmd = "pip3 uninstall -y -r requirements.txt"
                 for item in execute(bash_cmd):
                     print(item, end="")
             except Exception as e:
+                reinstall_cmd = "pip3 install -r requirements.txt"
+                subprocess.Popen(reinstall_cmd.split(), stdout=subprocess.PIPE)
+                print("Uninstall failed, trying adding the sudo option.")
                 print(e)
             else:
                 if os.path.isfile("/usr/local/bin/cis-integration") and os.path.isfile("/usr/local/bin/ci"):

--- a/src/main.py
+++ b/src/main.py
@@ -58,7 +58,7 @@ def main():
             except Exception as e:
                 reinstall_cmd = "pip3 install -r requirements.txt"
                 subprocess.Popen(reinstall_cmd.split(), stdout=subprocess.PIPE)
-                print("Uninstall failed, trying adding the sudo option.")
+                print("Uninstall failed, try again using the sudo option.")
                 print(e)
             else:
                 if os.path.isfile("/usr/local/bin/cis-integration") and os.path.isfile("/usr/local/bin/ci"):

--- a/src/main.py
+++ b/src/main.py
@@ -46,12 +46,16 @@ def main():
         #removes the ci and cis-integration command from system
         confirm = input("Are you sure you wish to uninstall? (y/n): ").lower()
         if confirm == 'y' or confirm == 'yes':
-            bash_cmd = "pip3 uninstall -y -r requirements.txt"
-            for item in execute(bash_cmd):
-                print(item, end="")
-            if os.path.isfile("/usr/local/bin/cis-integration") and os.path.isfile("/usr/local/bin/ci"):
-                os.remove("/usr/local/bin/cis-integration")
-                os.remove("/usr/local/bin/ci")
+            try:
+                bash_cmd = "pip3 uninstall -y -r requirements.txt"
+                for item in execute(bash_cmd):
+                    print(item, end="")
+            except Exception as e:
+                print(e)
+            else:
+                if os.path.isfile("/usr/local/bin/cis-integration") and os.path.isfile("/usr/local/bin/ci"):
+                    os.remove("/usr/local/bin/cis-integration")
+                    os.remove("/usr/local/bin/ci")
         else:
             sys.exit(1)
 


### PR DESCRIPTION
I'm unsure as to why a permission error was encountered in the first place so I'm still looking into that. However, this change should allow the uninstall process to run normally except this time if a problem occurs the program wont crash and it will print out the caught exception. In addition, if there was an exception caught the removal of `ci` and `cis-integration` (our entry-points) is not done. This is where I would like some feedback from y'all. 

If an exception occurs during the uninstall what do y'all is the best course of action? Should I automatically reinstall the dependencies to avoid having some installed and others not? Let me know what you think.

Note: I also removed the detect secrets line in the requirements.txt since the user will not need this to run the CLI. 