### PR TITLE
Removed confusing message when certificate is created

### DIFF
--- a/src/iks/certcreate_iks.py
+++ b/src/iks/certcreate_iks.py
@@ -52,7 +52,6 @@ class SecretCertificateCreator:
                 keepgoing = False
             elif cert_response.status_code == 500:
                 print("Waiting for a response from the certificate manager...")
-                print(cert_response.json())
                 time.sleep(2)
             else:
                 print(Color.RED+"ERROR: Failed to create secret for IKS with error code " +


### PR DESCRIPTION
When we order a certificate in the certificate manager, we have to wait for the process to complete before we add it as a secret to iks. Our code was printing the error message that appeared when our certificate manager was still busy, which would be misleading to the user, since it makes it seem like something went wrong, when we're really just waiting for the certificate to finish being created. I removed that error message.